### PR TITLE
feature/IDE-6-integration | RepoListView와 EditorView 연동

### DIFF
--- a/Sources/Zero/ZeroApp.swift
+++ b/Sources/Zero/ZeroApp.swift
@@ -7,13 +7,24 @@ struct ZeroApp: App {
     var body: some Scene {
         WindowGroup {
             Group {
-                if appState.isLoggedIn {
-                    RepoListView()
-                } else {
+                if !appState.isLoggedIn {
                     LoginView()
+                } else if appState.isEditing, let session = appState.activeSession {
+                    EditorView(session: session)
+                        .toolbar {
+                            ToolbarItem(placement: .navigation) {
+                                Button(action: { appState.closeEditor() }) {
+                                    Label("Back", systemImage: "chevron.left")
+                                }
+                            }
+                        }
+                } else {
+                    RepoListView()
                 }
             }
             .environmentObject(appState)
         }
+        .windowStyle(.automatic)
+        .defaultSize(width: 1200, height: 800)
     }
 }


### PR DESCRIPTION
## Context
- **Issue**: #11
- **Type**:
  - [x] `feat`
  - [ ] `fix`
  - [ ] `refactor`
  - [ ] `docs`
  - [ ] `etc`

## Summary
RepoListView의 버튼들과 EditorView를 연동하고, 세션 라이프사이클 관리 기능을 추가했습니다.

## Key Changes
- **AppState**: `activeSession`, `isEditing` 상태 추가, `startSession`/`resumeSession`/`closeEditor`/`deleteSession` 메서드 구현
- **RepoListView**: "Open" 버튼 → 세션 시작, "Resume" 버튼 → 세션 재개, 삭제 버튼 추가
- **ZeroApp**: `isEditing` 상태에 따라 EditorView로 전환
- **LoadingOverlay**: 컨테이너 생성 중 로딩 UI

## Screenshots (Optional)
(Xcode에서 실행 필요)

## Checklist
- [x] 커밋 메시지 컨벤션을 준수했습니다.
- [x] 변경 사항에 대한 테스트를 진행했습니다. (swift test 통과)
- [x] 불필요한 공백이나 주석을 제거했습니다.