### PR TITLE
feature/IDE-8-lightweight-container | 초경량 컨테이너 적용 (Alpine Linux)

### DIFF
--- a/Sources/Zero/Services/ContainerOrchestrator.swift
+++ b/Sources/Zero/Services/ContainerOrchestrator.swift
@@ -12,7 +12,7 @@ extension DockerService: DockerRunning {}
 class ContainerOrchestrator {
     private let dockerService: DockerRunning
     private let sessionManager: SessionManager
-    private let baseImage = "ubuntu:22.04"
+    private let baseImage = "alpine:latest"
     
     init(dockerService: DockerRunning, sessionManager: SessionManager) {
         self.dockerService = dockerService
@@ -27,8 +27,8 @@ class ContainerOrchestrator {
         // 2. 컨테이너 실행
         _ = try dockerService.runContainer(image: baseImage, name: containerName)
         
-        // 2-1. Git 설치 (Ubuntu 이미지에 git이 없으므로 설치 필요)
-        _ = try dockerService.executeShell(container: containerName, script: "apt-get update && apt-get install -y git")
+        // 2-1. Git 설치 (Alpine 이미지에 git이 없으므로 설치 필요)
+        _ = try dockerService.executeShell(container: containerName, script: "apk add --no-cache git")
         
         // 3. Git Clone (토큰 주입)
         let gitService = GitService(runner: dockerService as! ContainerRunning)

--- a/Tests/ZeroTests/ContainerOrchestratorTests.swift
+++ b/Tests/ZeroTests/ContainerOrchestratorTests.swift
@@ -5,6 +5,7 @@ import XCTest
 class MockDockerService: DockerRunning, ContainerRunning {
     var didRunContainer = false
     var lastContainerName: String?
+    var lastImageName: String?
     var executedScripts: [String] = []
     
     // 호환성을 위한 계산 속성
@@ -24,6 +25,7 @@ class MockDockerService: DockerRunning, ContainerRunning {
     func runContainer(image: String, name: String) throws -> String {
         didRunContainer = true
         lastContainerName = name
+        lastImageName = image
         return "container-id-123"
     }
 }
@@ -66,9 +68,10 @@ final class ContainerOrchestratorTests: XCTestCase {
         
         // Then
         XCTAssertTrue(mockDocker.didRunContainer)
+        XCTAssertEqual(mockDocker.lastImageName, "alpine:latest")
         
-        // Git 설치 확인
-        XCTAssertTrue(mockDocker.executedScripts.contains { $0.contains("apt-get install -y git") })
+        // Git 설치 확인 (Alpine: apk add)
+        XCTAssertTrue(mockDocker.executedScripts.contains { $0.contains("apk add --no-cache git") })
         
         XCTAssertNotNil(session)
         XCTAssertEqual(session.repoURL, repo.cloneURL)


### PR DESCRIPTION
## Context
- **Issue**: 컨테이너가 무거워서 초기 구동 속도 개선 필요
- **Type**: feat

## Summary
Base Image를 `ubuntu:22.04`(약 70MB)에서 `alpine:latest`(약 5MB)로 변경하여 가볍게 만듦.

## Changes
- **Image**: `ubuntu:22.04` -> `alpine:latest`
- **Command**: `apt-get install -y git` -> `apk add --no-cache git`

## Checklist
- [x] TDD (Red -> Green)
- [x] 단위 테스트 통과 (ContainerOrchestratorTests)
