### PR TITLE
feature/IDE-8-org-support | Organization 레포지토리 지원

### DIFF
--- a/Sources/Zero/Models/Organization.swift
+++ b/Sources/Zero/Models/Organization.swift
@@ -1,0 +1,15 @@
+import Foundation
+
+struct Organization: Codable, Identifiable, Hashable {
+    let id: Int
+    let login: String
+    let avatarURL: String?
+    let description: String?
+    
+    enum CodingKeys: String, CodingKey {
+        case id
+        case login
+        case avatarURL = "avatar_url"
+        case description
+    }
+}

--- a/Sources/Zero/Services/GitHubService.swift
+++ b/Sources/Zero/Services/GitHubService.swift
@@ -8,9 +8,13 @@ class GitHubService {
         self.token = token
     }
     
-    func createFetchReposRequest(page: Int = 1) -> URLRequest {
+    func createFetchReposRequest(page: Int = 1, type: String? = nil) -> URLRequest {
         // per_page=30 (기본값), sort=updated
-        let urlString = "\(baseURL)/user/repos?per_page=30&sort=updated&page=\(page)"
+        var urlString = "\(baseURL)/user/repos?per_page=30&sort=updated&page=\(page)"
+        if let type = type {
+            urlString += "&type=\(type)"
+        }
+        
         let url = URL(string: urlString)!
         var request = URLRequest(url: url)
         request.httpMethod = "GET"
@@ -19,8 +23,51 @@ class GitHubService {
         return request
     }
     
-    func fetchRepositories(page: Int = 1) async throws -> [Repository] {
-        let request = createFetchReposRequest(page: page)
+    func createFetchOrgsRequest() -> URLRequest {
+        let url = URL(string: "\(baseURL)/user/orgs")!
+        var request = URLRequest(url: url)
+        request.httpMethod = "GET"
+        request.setValue("Bearer \(token)", forHTTPHeaderField: "Authorization")
+        request.setValue("application/vnd.github+json", forHTTPHeaderField: "Accept")
+        return request
+    }
+    
+    func createFetchOrgReposRequest(org: String, page: Int = 1) -> URLRequest {
+        let urlString = "\(baseURL)/orgs/\(org)/repos?per_page=30&sort=updated&page=\(page)"
+        let url = URL(string: urlString)!
+        var request = URLRequest(url: url)
+        request.httpMethod = "GET"
+        request.setValue("Bearer \(token)", forHTTPHeaderField: "Authorization")
+        request.setValue("application/vnd.github+json", forHTTPHeaderField: "Accept")
+        return request
+    }
+    
+    func fetchRepositories(page: Int = 1, type: String? = nil) async throws -> [Repository] {
+        let request = createFetchReposRequest(page: page, type: type)
+        let (data, response) = try await URLSession.shared.data(for: request)
+        
+        guard let httpResponse = response as? HTTPURLResponse,
+              httpResponse.statusCode == 200 else {
+            throw URLError(.badServerResponse)
+        }
+        
+        return try JSONDecoder().decode([Repository].self, from: data)
+    }
+    
+    func fetchOrganizations() async throws -> [Organization] {
+        let request = createFetchOrgsRequest()
+        let (data, response) = try await URLSession.shared.data(for: request)
+        
+        guard let httpResponse = response as? HTTPURLResponse,
+              httpResponse.statusCode == 200 else {
+            throw URLError(.badServerResponse)
+        }
+        
+        return try JSONDecoder().decode([Organization].self, from: data)
+    }
+    
+    func fetchOrgRepositories(org: String, page: Int = 1) async throws -> [Repository] {
+        let request = createFetchOrgReposRequest(org: org, page: page)
         let (data, response) = try await URLSession.shared.data(for: request)
         
         guard let httpResponse = response as? HTTPURLResponse,

--- a/Sources/Zero/Views/LoginView.swift
+++ b/Sources/Zero/Views/LoginView.swift
@@ -4,6 +4,7 @@ struct LoginView: View {
     @EnvironmentObject var appState: AppState
     @State private var tokenInput: String = ""
     @State private var showError: Bool = false
+    @FocusState private var isTokenFocused: Bool
     
     var body: some View {
         VStack(spacing: 24) {
@@ -32,6 +33,7 @@ struct LoginView: View {
                 SecureField("ghp_xxxx...", text: $tokenInput)
                     .textFieldStyle(.roundedBorder)
                     .frame(width: 300)
+                    .focused($isTokenFocused)
             }
             
             Button("Sign In") {
@@ -48,6 +50,9 @@ struct LoginView: View {
         }
         .padding(40)
         .frame(minWidth: 400, minHeight: 350)
+        .onAppear {
+            isTokenFocused = true
+        }
     }
     
     private func signIn() {

--- a/Sources/Zero/Views/MonacoWebView.swift
+++ b/Sources/Zero/Views/MonacoWebView.swift
@@ -61,6 +61,8 @@ struct MonacoWebView: NSViewRepresentable {
                     .replacingOccurrences(of: "'", with: "\\'")
                     .replacingOccurrences(of: "\n", with: "\\n")
                 webView?.evaluateJavaScript("setContent('\(escaped)', '\(parent.language)')")
+            } else if message.name == "contentChanged", let body = message.body as? String {
+                parent.content = body
             }
         }
     }
@@ -92,6 +94,12 @@ struct MonacoWebView: NSViewRepresentable {
                     minimap: { enabled: true },
                     automaticLayout: true
                 });
+                
+                // Add change listener
+                editor.onDidChangeModelContent(() => {
+                    window.webkit.messageHandlers.contentChanged.postMessage(editor.getValue());
+                });
+                
                 window.webkit.messageHandlers.editorReady.postMessage('ready');
             });
             function setContent(content, language) {

--- a/Sources/Zero/Views/RepoListView.swift
+++ b/Sources/Zero/Views/RepoListView.swift
@@ -16,6 +16,32 @@ struct RepoListView: View {
     var body: some View {
         NavigationSplitView {
             VStack(alignment: .leading) {
+                // Organization Picker
+                if !appState.organizations.isEmpty {
+                    HStack {
+                        Text("Context")
+                            .font(.caption)
+                            .foregroundStyle(.secondary)
+                        Spacer()
+                        Picker("Organization", selection: $appState.selectedOrg) {
+                            Text("Personal").tag(Optional<Organization>.none)
+                            ForEach(appState.organizations) { org in
+                                Text(org.login).tag(Optional(org))
+                            }
+                        }
+                        .labelsHidden()
+                        .pickerStyle(.menu)
+                        .onChange(of: appState.selectedOrg) { _ in
+                            Task { await appState.fetchRepositories() }
+                        }
+                    }
+                    .padding(.horizontal)
+                    .padding(.top, 8)
+                    
+                    Divider()
+                        .padding(.vertical, 8)
+                }
+                
                 // Active Sessions
                 if !appState.sessions.isEmpty {
                     Section {
@@ -79,6 +105,7 @@ struct RepoListView: View {
                 .foregroundStyle(.secondary)
         }
         .task {
+            await appState.fetchOrganizations()
             await appState.fetchRepositories()
             appState.loadSessions()
         }

--- a/Tests/ZeroTests/GitHubServiceTests.swift
+++ b/Tests/ZeroTests/GitHubServiceTests.swift
@@ -9,13 +9,45 @@ final class GitHubServiceTests: XCTestCase {
         let service = GitHubService(token: token)
         
         // When
-        let request = service.createFetchReposRequest(page: 2)
+        let request = service.createFetchReposRequest(page: 2, type: "owner")
         
         // Then
         let url = request.url?.absoluteString
-        XCTAssertTrue(url?.contains("per_page=30") ?? false) // 30개씩 끊어서 가져오기
+        XCTAssertTrue(url?.contains("per_page=30") ?? false)
         XCTAssertTrue(url?.contains("page=2") ?? false)
+        XCTAssertTrue(url?.contains("type=owner") ?? false) // type 파라미터 확인
         XCTAssertTrue(url?.contains("sort=updated") ?? false)
+        XCTAssertEqual(request.url?.path, "/user/repos")
+    }
+    
+    func testFetchOrgsRequestCreation() throws {
+        // Given
+        let token = "ghp_test_token"
+        let service = GitHubService(token: token)
+        
+        // When
+        let request = service.createFetchOrgsRequest()
+        
+        // Then
+        XCTAssertEqual(request.url?.path, "/user/orgs")
+        XCTAssertEqual(request.httpMethod, "GET")
+        XCTAssertEqual(request.value(forHTTPHeaderField: "Authorization"), "Bearer ghp_test_token")
+    }
+    
+    func testFetchOrgReposRequestCreation() throws {
+        // Given
+        let token = "ghp_test_token"
+        let service = GitHubService(token: token)
+        let orgName = "zero-ide"
+        
+        // When
+        let request = service.createFetchOrgReposRequest(org: orgName, page: 3)
+        
+        // Then
+        let url = request.url?.absoluteString
+        XCTAssertTrue(url?.contains("/orgs/zero-ide/repos") ?? false)
+        XCTAssertTrue(url?.contains("page=3") ?? false)
+        XCTAssertEqual(request.httpMethod, "GET")
     }
     
     func testDecodeRepositories() throws {
@@ -41,5 +73,27 @@ final class GitHubServiceTests: XCTestCase {
         XCTAssertEqual(repos.first?.name, "test-repo")
         XCTAssertEqual(repos.first?.fullName, "user/test-repo")
         XCTAssertEqual(repos.first?.isPrivate, false)
+    }
+    
+    func testDecodeOrganizations() throws {
+        // Given
+        let json = """
+        [
+            {
+                "id": 1,
+                "login": "github",
+                "description": "How people build software.",
+                "avatar_url": "https://github.com/images/error/octocat_happy.gif"
+            }
+        ]
+        """.data(using: .utf8)!
+        
+        // When
+        let orgs = try JSONDecoder().decode([Organization].self, from: json)
+        
+        // Then
+        XCTAssertEqual(orgs.count, 1)
+        XCTAssertEqual(orgs.first?.login, "github")
+        XCTAssertEqual(orgs.first?.description, "How people build software.")
     }
 }


### PR DESCRIPTION
## Context
- **Issue**: 개인 레포지토리와 Organization 레포지토리가 섞여 있어서 관리하기 어려움
- **Type**: feat

## Summary
Organization 별로 레포지토리를 필터링해서 볼 수 있도록 개선.

## Changes
1. **GitHubService**:
   - `/user/orgs` (조직 목록 조회)
   - `/orgs/{org}/repos` (조직 레포 조회)
2. **AppState**:
   - `organizations`, `selectedOrg` 상태 추가
   - `fetchRepositories` 로직 수정: 선택된 Org가 있으면 해당 Org의 레포만 로드
3. **UI**:
   - 사이드바 상단에 Organization Picker 추가 (Personal / Org1 / Org2 ...)
   - 선택 시 해당 컨텍스트의 레포지토리만 표시

## Checklist
- [x] TDD (Red -> Green)
- [x] GitHubServiceTests: API 요청 URL 검증
- [x] AppStateTests: Org 선택 및 레포 로드 로직 검증