### PR TITLE
refactor/IDE-10-code-cleanup | Constants 및 FileIconHelper 추출

### DIFF
--- a/Sources/Zero/Constants.swift
+++ b/Sources/Zero/Constants.swift
@@ -1,0 +1,24 @@
+import Foundation
+
+enum Constants {
+    enum Docker {
+        static let path = "/usr/local/bin/docker"
+        static let baseImage = "alpine:latest"
+        static let workspacePath = "/workspace"
+    }
+    
+    enum Keychain {
+        static let service = "com.zero.ide"
+        static let account = "github_token"
+    }
+    
+    enum GitHub {
+        static let pageSize = 30
+    }
+    
+    enum UI {
+        static let sidebarMinWidth: CGFloat = 220
+        static let sidebarIdealWidth: CGFloat = 260
+        static let sidebarMaxWidth: CGFloat = 400
+    }
+}

--- a/Sources/Zero/Helpers/FileIconHelper.swift
+++ b/Sources/Zero/Helpers/FileIconHelper.swift
@@ -1,0 +1,97 @@
+import SwiftUI
+
+enum FileIconHelper {
+    /// 파일 확장자에 따른 아이콘 이름과 색상 반환
+    static func iconInfo(for filename: String, isDirectory: Bool) -> (name: String, color: Color) {
+        if isDirectory {
+            return ("folder.fill", .yellow)
+        }
+        
+        let ext = (filename as NSString).pathExtension.lowercased()
+        let name = filename.lowercased()
+        
+        // Special files
+        if name == "dockerfile" { return ("shippingbox.fill", .blue) }
+        if name == "readme.md" { return ("book.fill", .blue) }
+        if name == ".gitignore" { return ("eye.slash", .orange) }
+        if name.contains("license") { return ("doc.text.fill", .green) }
+        
+        switch ext {
+        case "swift": return ("swift", .orange)
+        case "java": return ("cup.and.saucer.fill", .red)
+        case "kt", "kts": return ("k.square.fill", .purple)
+        case "js": return ("j.square.fill", .yellow)
+        case "ts": return ("t.square.fill", .blue)
+        case "py": return ("p.square.fill", .cyan)
+        case "rb": return ("r.square.fill", .red)
+        case "go": return ("g.square.fill", .cyan)
+        case "rs": return ("r.square.fill", .orange)
+        case "json": return ("curlybraces", .yellow)
+        case "xml", "plist": return ("chevron.left.forwardslash.chevron.right", .orange)
+        case "html": return ("globe", .orange)
+        case "css", "scss", "sass": return ("paintbrush.fill", .pink)
+        case "md", "markdown": return ("doc.richtext.fill", .blue)
+        case "yml", "yaml": return ("list.bullet.rectangle.fill", .pink)
+        case "sh", "bash", "zsh": return ("terminal.fill", .green)
+        case "sql": return ("cylinder.fill", .blue)
+        case "png", "jpg", "jpeg", "gif", "svg", "ico": return ("photo.fill", .purple)
+        case "pdf": return ("doc.fill", .red)
+        case "zip", "tar", "gz", "rar": return ("doc.zipper", .gray)
+        case "gradle": return ("g.square.fill", .green)
+        case "properties": return ("gearshape.fill", .gray)
+        case "env": return ("key.fill", .yellow)
+        case "lock": return ("lock.fill", .gray)
+        default: return ("doc.fill", .secondary)
+        }
+    }
+    
+    /// 파일 확장자에 따른 언어 이름 반환 (syntax highlighting용)
+    static func languageName(for filename: String) -> String {
+        let ext = (filename as NSString).pathExtension.lowercased()
+        switch ext {
+        case "swift": return "swift"
+        case "js": return "javascript"
+        case "ts": return "typescript"
+        case "py": return "python"
+        case "java": return "java"
+        case "kt", "kts": return "kotlin"
+        case "json": return "json"
+        case "html": return "html"
+        case "css": return "css"
+        case "md": return "markdown"
+        case "yaml", "yml": return "yaml"
+        case "xml": return "xml"
+        case "sh": return "shell"
+        case "c", "h": return "c"
+        case "cpp", "hpp": return "cpp"
+        case "go": return "go"
+        case "rs": return "rust"
+        case "rb": return "ruby"
+        case "php": return "php"
+        case "sql": return "sql"
+        case "dockerfile": return "dockerfile"
+        default: return "plaintext"
+        }
+    }
+    
+    /// 언어 표시 이름 반환
+    static func languageDisplayName(_ lang: String) -> String {
+        switch lang {
+        case "swift": return "Swift"
+        case "java": return "Java"
+        case "kotlin": return "Kotlin"
+        case "javascript": return "JavaScript"
+        case "typescript": return "TypeScript"
+        case "python": return "Python"
+        case "json": return "JSON"
+        case "html": return "HTML"
+        case "css": return "CSS"
+        case "markdown": return "Markdown"
+        case "yaml": return "YAML"
+        case "shell": return "Shell"
+        case "dockerfile": return "Dockerfile"
+        case "plaintext": return "Plain Text"
+        default: return lang.capitalized
+        }
+    }
+}

--- a/Sources/Zero/Services/ContainerOrchestrator.swift
+++ b/Sources/Zero/Services/ContainerOrchestrator.swift
@@ -12,7 +12,7 @@ extension DockerService: DockerRunning {}
 class ContainerOrchestrator {
     private let dockerService: DockerRunning
     private let sessionManager: SessionManager
-    private let baseImage = "alpine:latest"
+    private let baseImage = Constants.Docker.baseImage
     
     init(dockerService: DockerRunning, sessionManager: SessionManager) {
         self.dockerService = dockerService

--- a/Sources/Zero/Services/DockerService.swift
+++ b/Sources/Zero/Services/DockerService.swift
@@ -2,7 +2,7 @@ import Foundation
 
 struct DockerService {
     let runner: CommandRunning
-    let dockerPath = "/usr/local/bin/docker" // 추후 환경변수 등에서 탐색 가능
+    let dockerPath = Constants.Docker.path
     
     init(runner: CommandRunning = CommandRunner()) {
         self.runner = runner

--- a/Sources/Zero/Views/AppState.swift
+++ b/Sources/Zero/Views/AppState.swift
@@ -19,10 +19,10 @@ class AppState: ObservableObject {
     @Published var selectedOrg: Organization? = nil
     
     // 페이지 크기 (테스트 시 조정 가능)
-    var pageSize: Int = 30
+    var pageSize: Int = Constants.GitHub.pageSize
     
-    private let keychainService = "com.zero.ide"
-    private let keychainAccount = "github_token"
+    private let keychainService = Constants.Keychain.service
+    private let keychainAccount = Constants.Keychain.account
     private let sessionManager = SessionManager()
     private lazy var orchestrator: ContainerOrchestrator = {
         let docker = DockerService()

--- a/Sources/Zero/Views/EditorView.swift
+++ b/Sources/Zero/Views/EditorView.swift
@@ -45,13 +45,15 @@ struct EditorView: View {
                             .foregroundStyle(.secondary)
                         
                         if let file = selectedFile {
+                            let iconInfo = FileIconHelper.iconInfo(for: file.name, isDirectory: false)
+                            
                             Image(systemName: "chevron.right")
                                 .font(.system(size: 9))
                                 .foregroundStyle(.quaternary)
                             
-                            Image(systemName: iconForFile(file.name))
+                            Image(systemName: iconInfo.name)
                                 .font(.system(size: 12))
-                                .foregroundStyle(colorForFile(file.name))
+                                .foregroundStyle(iconInfo.color)
                             
                             Text(file.name)
                                 .font(.system(size: 13, weight: .medium))
@@ -100,7 +102,7 @@ struct EditorView: View {
                         HStack(spacing: 4) {
                             Image(systemName: "chevron.left.forwardslash.chevron.right")
                                 .font(.system(size: 9))
-                            Text(languageDisplayName(currentLanguage))
+                            Text(FileIconHelper.languageDisplayName(currentLanguage))
                                 .font(.system(size: 11))
                         }
                         .foregroundStyle(.secondary)
@@ -145,68 +147,11 @@ struct EditorView: View {
     
     // MARK: - Helpers
     
-    private func iconForFile(_ filename: String) -> String {
-        let ext = (filename as NSString).pathExtension.lowercased()
-        switch ext {
-        case "swift": return "swift"
-        case "java", "kt", "kts": return "cup.and.saucer.fill"
-        case "js": return "j.square.fill"
-        case "ts": return "t.square.fill"
-        case "py": return "p.square.fill"
-        case "json": return "curlybraces"
-        case "md": return "doc.richtext.fill"
-        case "html", "css": return "globe"
-        case "yml", "yaml": return "list.bullet.rectangle.fill"
-        case "sh": return "terminal.fill"
-        case "dockerfile": return "shippingbox.fill"
-        default: return "doc.text.fill"
-        }
-    }
-    
-    private func colorForFile(_ filename: String) -> Color {
-        let ext = (filename as NSString).pathExtension.lowercased()
-        switch ext {
-        case "swift": return .orange
-        case "java": return .red
-        case "kt", "kts": return .purple
-        case "js": return .yellow
-        case "ts": return .blue
-        case "py": return .cyan
-        case "json": return .yellow
-        case "md": return .blue
-        case "html": return .orange
-        case "css": return .pink
-        case "yml", "yaml": return .pink
-        case "sh": return .green
-        default: return .secondary
-        }
-    }
-    
-    private func languageDisplayName(_ lang: String) -> String {
-        switch lang {
-        case "swift": return "Swift"
-        case "java": return "Java"
-        case "kotlin": return "Kotlin"
-        case "javascript": return "JavaScript"
-        case "typescript": return "TypeScript"
-        case "python": return "Python"
-        case "json": return "JSON"
-        case "html": return "HTML"
-        case "css": return "CSS"
-        case "markdown": return "Markdown"
-        case "yaml": return "YAML"
-        case "shell": return "Shell"
-        case "dockerfile": return "Dockerfile"
-        case "plaintext": return "Plain Text"
-        default: return lang.capitalized
-        }
-    }
-    
     private func loadFile(_ file: FileItem) {
         guard !file.isDirectory else { return }
         
         isLoadingFile = true
-        currentLanguage = detectLanguage(for: file.name)
+        currentLanguage = FileIconHelper.languageName(for: file.name)
         
         Task {
             do {
@@ -251,34 +196,6 @@ struct EditorView: View {
                     isSaving = false
                 }
             }
-        }
-    }
-    
-    private func detectLanguage(for filename: String) -> String {
-        let ext = (filename as NSString).pathExtension.lowercased()
-        switch ext {
-        case "swift": return "swift"
-        case "js": return "javascript"
-        case "ts": return "typescript"
-        case "py": return "python"
-        case "java": return "java"
-        case "kt", "kts": return "kotlin"
-        case "json": return "json"
-        case "html": return "html"
-        case "css": return "css"
-        case "md": return "markdown"
-        case "yaml", "yml": return "yaml"
-        case "xml": return "xml"
-        case "sh": return "shell"
-        case "c", "h": return "c"
-        case "cpp", "hpp": return "cpp"
-        case "go": return "go"
-        case "rs": return "rust"
-        case "rb": return "ruby"
-        case "php": return "php"
-        case "sql": return "sql"
-        case "dockerfile": return "dockerfile"
-        default: return "plaintext"
         }
     }
 }

--- a/Sources/Zero/Views/FileExplorerView.swift
+++ b/Sources/Zero/Views/FileExplorerView.swift
@@ -226,56 +226,10 @@ struct FileRowView: View {
     
     @ViewBuilder
     private var fileIconView: some View {
-        let (iconName, iconColor) = fileIconInfo(for: file)
-        
-        if file.isDirectory {
-            Image(systemName: isExpanded ? "folder.fill" : "folder.fill")
-                .font(.system(size: 14))
-                .foregroundStyle(Color.yellow)
-        } else {
-            Image(systemName: iconName)
-                .font(.system(size: 13))
-                .foregroundStyle(iconColor)
-        }
-    }
-    
-    private func fileIconInfo(for file: FileItem) -> (String, Color) {
-        let ext = (file.name as NSString).pathExtension.lowercased()
-        let name = file.name.lowercased()
-        
-        // Special files
-        if name == "dockerfile" { return ("shippingbox.fill", .blue) }
-        if name == "readme.md" { return ("book.fill", .blue) }
-        if name == ".gitignore" { return ("eye.slash", .orange) }
-        if name.contains("license") { return ("doc.text.fill", .green) }
-        
-        switch ext {
-        case "swift": return ("swift", .orange)
-        case "java": return ("cup.and.saucer.fill", .red)
-        case "kt", "kts": return ("k.square.fill", .purple)
-        case "js": return ("j.square.fill", .yellow)
-        case "ts": return ("t.square.fill", .blue)
-        case "py": return ("p.square.fill", .cyan)
-        case "rb": return ("r.square.fill", .red)
-        case "go": return ("g.square.fill", .cyan)
-        case "rs": return ("r.square.fill", .orange)
-        case "json": return ("curlybraces", .yellow)
-        case "xml", "plist": return ("chevron.left.forwardslash.chevron.right", .orange)
-        case "html": return ("globe", .orange)
-        case "css", "scss", "sass": return ("paintbrush.fill", .pink)
-        case "md", "markdown": return ("doc.richtext.fill", .blue)
-        case "yml", "yaml": return ("list.bullet.rectangle.fill", .pink)
-        case "sh", "bash", "zsh": return ("terminal.fill", .green)
-        case "sql": return ("cylinder.fill", .blue)
-        case "png", "jpg", "jpeg", "gif", "svg", "ico": return ("photo.fill", .purple)
-        case "pdf": return ("doc.fill", .red)
-        case "zip", "tar", "gz", "rar": return ("doc.zipper", .gray)
-        case "gradle": return ("g.square.fill", .green)
-        case "properties": return ("gearshape.fill", .gray)
-        case "env": return ("key.fill", .yellow)
-        case "lock": return ("lock.fill", .gray)
-        default: return ("doc.fill", .secondary)
-        }
+        let info = FileIconHelper.iconInfo(for: file.name, isDirectory: file.isDirectory)
+        Image(systemName: info.name)
+            .font(.system(size: file.isDirectory ? 14 : 13))
+            .foregroundStyle(info.color)
     }
     
     private func toggleExpand() {


### PR DESCRIPTION
## Context
- 코드 중복 제거 및 유지보수성 향상을 위한 리팩토링

## Summary
하드코딩된 상수와 중복된 파일 아이콘 로직을 별도 파일로 추출.

## Changes
1. **Constants.swift** 생성
   - Docker 관련 상수 (path, baseImage, workspacePath)
   - Keychain 관련 상수 (service, account)
   - GitHub 관련 상수 (pageSize)
   - UI 관련 상수 (sidebar width)

2. **FileIconHelper.swift** 생성
   - `iconInfo(for:isDirectory:)` - 파일 아이콘/색상 매핑
   - `languageName(for:)` - syntax highlighting 언어 매핑
   - `languageDisplayName(_:)` - 표시용 언어 이름

3. **EditorView, FileExplorerView** 정리
   - 중복 함수 제거, FileIconHelper 사용으로 대체

## Checklist
- [x] 빌드 성공
- [x] 22개 테스트 통과
- [x] 기존 기능 동작 유지