### PR TITLE
feature/IDE-9-jdk-model | JDK Configuration 모델 구현

### DIFF
--- a/Sources/Zero/Models/JDKConfiguration.swift
+++ b/Sources/Zero/Models/JDKConfiguration.swift
@@ -1,0 +1,53 @@
+import Foundation
+
+struct JDKConfiguration: Codable, Identifiable, Equatable {
+    let id: UUID
+    let name: String
+    let image: String
+    let version: String
+    let isCustom: Bool
+    
+    init(id: UUID, name: String, image: String, version: String, isCustom: Bool) {
+        self.id = id
+        self.name = name
+        self.image = image
+        self.version = version
+        self.isCustom = isCustom
+    }
+}
+
+extension JDKConfiguration {
+    static let predefined: [JDKConfiguration] = [
+        JDKConfiguration(id: UUID(), name: "OpenJDK 21", image: "openjdk:21-slim", version: "21", isCustom: false),
+        JDKConfiguration(id: UUID(), name: "OpenJDK 17", image: "openjdk:17-slim", version: "17", isCustom: false),
+        JDKConfiguration(id: UUID(), name: "OpenJDK 11", image: "openjdk:11-slim", version: "11", isCustom: false),
+        JDKConfiguration(id: UUID(), name: "Eclipse Temurin 21", image: "eclipse-temurin:21-jdk", version: "21", isCustom: false),
+        JDKConfiguration(id: UUID(), name: "Amazon Corretto 21", image: "amazoncorretto:21", version: "21", isCustom: false),
+    ]
+}
+
+struct BuildConfiguration: Codable, Equatable {
+    var selectedJDK: JDKConfiguration
+    var buildTool: BuildTool
+    var customArgs: [String]
+    
+    enum BuildTool: String, Codable, Equatable {
+        case javac, maven, gradle
+    }
+    
+    init(selectedJDK: JDKConfiguration, buildTool: BuildTool, customArgs: [String]) {
+        self.selectedJDK = selectedJDK
+        self.buildTool = buildTool
+        self.customArgs = customArgs
+    }
+}
+
+extension BuildConfiguration {
+    static var `default`: BuildConfiguration {
+        BuildConfiguration(
+            selectedJDK: JDKConfiguration.predefined[0],
+            buildTool: .javac,
+            customArgs: []
+        )
+    }
+}

--- a/Tests/ZeroTests/JDKConfigurationTests.swift
+++ b/Tests/ZeroTests/JDKConfigurationTests.swift
@@ -1,0 +1,109 @@
+import XCTest
+@testable import Zero
+
+class JDKConfigurationTests: XCTestCase {
+    
+    func testJDKConfigurationInitialization() {
+        // Given
+        let id = UUID()
+        let name = "OpenJDK 21"
+        let image = "openjdk:21-slim"
+        let version = "21"
+        
+        // When
+        let config = JDKConfiguration(
+            id: id,
+            name: name,
+            image: image,
+            version: version,
+            isCustom: false
+        )
+        
+        // Then
+        XCTAssertEqual(config.id, id)
+        XCTAssertEqual(config.name, name)
+        XCTAssertEqual(config.image, image)
+        XCTAssertEqual(config.version, version)
+        XCTAssertFalse(config.isCustom)
+    }
+    
+    func testJDKConfigurationPredefined() {
+        // When
+        let predefined = JDKConfiguration.predefined
+        
+        // Then
+        XCTAssertFalse(predefined.isEmpty)
+        XCTAssertTrue(predefined.contains { $0.name == "OpenJDK 21" })
+        XCTAssertTrue(predefined.contains { $0.name == "OpenJDK 17" })
+        XCTAssertTrue(predefined.contains { $0.name == "Eclipse Temurin 21" })
+    }
+    
+    func testJDKConfigurationCodable() throws {
+        // Given
+        let config = JDKConfiguration(
+            id: UUID(),
+            name: "Test JDK",
+            image: "test:21",
+            version: "21",
+            isCustom: true
+        )
+        
+        // When
+        let encoded = try JSONEncoder().encode(config)
+        let decoded = try JSONDecoder().decode(JDKConfiguration.self, from: encoded)
+        
+        // Then
+        XCTAssertEqual(config.id, decoded.id)
+        XCTAssertEqual(config.name, decoded.name)
+        XCTAssertEqual(config.image, decoded.image)
+        XCTAssertEqual(config.version, decoded.version)
+        XCTAssertEqual(config.isCustom, decoded.isCustom)
+    }
+}
+
+class BuildConfigurationTests: XCTestCase {
+    
+    func testBuildConfigurationInitialization() {
+        // Given
+        let jdk = JDKConfiguration.predefined[0]
+        
+        // When
+        let config = BuildConfiguration(
+            selectedJDK: jdk,
+            buildTool: .maven,
+            customArgs: ["-Xmx2g"]
+        )
+        
+        // Then
+        XCTAssertEqual(config.selectedJDK.id, jdk.id)
+        XCTAssertEqual(config.buildTool, .maven)
+        XCTAssertEqual(config.customArgs, ["-Xmx2g"])
+    }
+    
+    func testBuildConfigurationDefault() {
+        // When
+        let config = BuildConfiguration.default
+        
+        // Then
+        XCTAssertEqual(config.buildTool, .javac)
+        XCTAssertTrue(config.customArgs.isEmpty)
+    }
+    
+    func testBuildConfigurationCodable() throws {
+        // Given
+        let config = BuildConfiguration(
+            selectedJDK: JDKConfiguration.predefined[0],
+            buildTool: .gradle,
+            customArgs: []
+        )
+        
+        // When
+        let encoded = try JSONEncoder().encode(config)
+        let decoded = try JSONDecoder().decode(BuildConfiguration.self, from: encoded)
+        
+        // Then
+        XCTAssertEqual(config.selectedJDK.id, decoded.selectedJDK.id)
+        XCTAssertEqual(config.buildTool, decoded.buildTool)
+        XCTAssertEqual(config.customArgs, decoded.customArgs)
+    }
+}


### PR DESCRIPTION
## Context
- **Issue**: IDE-9
- **Type**:
  - [x] `feat`
  - [x] `test`

## Summary
Java 빌드 설정 기능의 첫 번째 단계로 JDKConfiguration 및 BuildConfiguration 모델을 구현.

## Key Changes
- test: JDKConfiguration 및 BuildConfiguration 테스트 작성 (Red)
- feat: JDKConfiguration 모델 구현 (Codable, Identifiable, Equatable)
- feat: BuildConfiguration 모델 구현 (BuildTool enum 포함)
- feat: 미리 정의된 JDK 이미지 목록 (OpenJDK, Eclipse Temurin, Corretto)

## 테스트 결과


## 다음 단계
- BuildConfigurationService 구현 (설정 저장/로드)
- Build Configuration UI 구현
- ExecutionService 연동

## ⚠️ 주의사항 / 리뷰 포인트
- Codable 프로토콜 준수 확인
- predefined JDK 이미지 목록 적절한지 확인