### PR TITLE
feature/IDE-9-build-config-service | BuildConfigurationService 구현

### DIFF
--- a/Sources/Zero/Services/BuildConfigurationService.swift
+++ b/Sources/Zero/Services/BuildConfigurationService.swift
@@ -1,0 +1,60 @@
+import Foundation
+
+protocol BuildConfigurationService {
+    func save(_ config: BuildConfiguration) throws
+    func load() throws -> BuildConfiguration
+    func reset() throws
+}
+
+enum BuildConfigurationError: Error {
+    case encodingFailed
+    case decodingFailed
+    case saveFailed
+    case loadFailed
+}
+
+class FileBasedBuildConfigurationService: BuildConfigurationService {
+    private let configPath: String
+    
+    init(configPath: String = "~/.zero/build-config.json") {
+        self.configPath = (configPath as NSString).expandingTildeInPath
+    }
+    
+    func save(_ config: BuildConfiguration) throws {
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = .prettyPrinted
+        
+        guard let data = try? encoder.encode(config) else {
+            throw BuildConfigurationError.encodingFailed
+        }
+        
+        let url = URL(fileURLWithPath: configPath)
+        let directory = url.deletingLastPathComponent()
+        
+        try? FileManager.default.createDirectory(
+            at: directory,
+            withIntermediateDirectories: true
+        )
+        
+        try data.write(to: url)
+    }
+    
+    func load() throws -> BuildConfiguration {
+        let url = URL(fileURLWithPath: configPath)
+        
+        guard FileManager.default.fileExists(atPath: configPath),
+              let data = try? Data(contentsOf: url) else {
+            return .default
+        }
+        
+        guard let config = try? JSONDecoder().decode(BuildConfiguration.self, from: data) else {
+            throw BuildConfigurationError.decodingFailed
+        }
+        
+        return config
+    }
+    
+    func reset() throws {
+        try save(.default)
+    }
+}

--- a/Tests/ZeroTests/BuildConfigurationServiceTests.swift
+++ b/Tests/ZeroTests/BuildConfigurationServiceTests.swift
@@ -1,0 +1,63 @@
+import XCTest
+@testable import Zero
+
+class BuildConfigurationServiceTests: XCTestCase {
+    
+    var service: BuildConfigurationService!
+    let testConfigPath = "/tmp/test-zero-build-config.json"
+    
+    override func setUp() {
+        super.setUp()
+        service = FileBasedBuildConfigurationService(configPath: testConfigPath)
+        try? FileManager.default.removeItem(atPath: testConfigPath)
+    }
+    
+    override func tearDown() {
+        try? FileManager.default.removeItem(atPath: testConfigPath)
+        super.tearDown()
+    }
+    
+    func testSaveAndLoadConfiguration() throws {
+        // Given
+        let config = BuildConfiguration(
+            selectedJDK: JDKConfiguration.predefined[0],
+            buildTool: .maven,
+            customArgs: ["-Xmx2g"]
+        )
+        
+        // When
+        try service.save(config)
+        let loaded = try service.load()
+        
+        // Then
+        XCTAssertEqual(loaded.selectedJDK.id, config.selectedJDK.id)
+        XCTAssertEqual(loaded.buildTool, config.buildTool)
+        XCTAssertEqual(loaded.customArgs, config.customArgs)
+    }
+    
+    func testLoadDefaultWhenNoFile() throws {
+        // When
+        let config = try service.load()
+        
+        // Then
+        XCTAssertEqual(config.buildTool, .javac)
+        XCTAssertTrue(config.customArgs.isEmpty)
+    }
+    
+    func testResetToDefault() throws {
+        // Given
+        let customConfig = BuildConfiguration(
+            selectedJDK: JDKConfiguration.predefined[2],
+            buildTool: .gradle,
+            customArgs: ["--info"]
+        )
+        try service.save(customConfig)
+        
+        // When
+        try service.reset()
+        let config = try service.load()
+        
+        // Then
+        XCTAssertEqual(config.buildTool, .javac)
+    }
+}


### PR DESCRIPTION
## Context
- **Issue**: IDE-9
- **Type**:
  - [x] feat
  - [x] test

## Summary
BuildConfigurationService 프로토콜 및 파일 기반 구현체 구현.

## Key Changes
- test: BuildConfigurationService 테스트 추가
- feat: BuildConfigurationService 프로토콜 정의
- feat: FileBasedBuildConfigurationService 구현
- feat: 설정 저장/로드/초기화 기능

## 테스트 결과


## 저장 위치
- ~/.zero/build-config.json

## 다음 단계
- Build Configuration UI 구현
- ExecutionService 연동

## 리뷰 포인트
- 파일 경로 처리 (tilde expansion)
- 에러 처리 적절한지 확인