### PR TITLE
feature/IDE-9-build-config-ui | Build Configuration UI 구현

### DIFF
--- a/Sources/Zero/Models/JDKConfiguration.swift
+++ b/Sources/Zero/Models/JDKConfiguration.swift
@@ -1,6 +1,6 @@
 import Foundation
 
-struct JDKConfiguration: Codable, Identifiable, Equatable {
+struct JDKConfiguration: Codable, Identifiable, Equatable, Hashable {
     let id: UUID
     let name: String
     let image: String

--- a/Sources/Zero/Views/BuildConfigurationView.swift
+++ b/Sources/Zero/Views/BuildConfigurationView.swift
@@ -1,0 +1,115 @@
+import SwiftUI
+
+struct BuildConfigurationView: View {
+    @State private var configuration: BuildConfiguration = .default
+    @State private var isCustomImage: Bool = false
+    @State private var customImage: String = ""
+    private let service: BuildConfigurationService = FileBasedBuildConfigurationService()
+    
+    var body: some View {
+        VStack(alignment: .leading, spacing: 20) {
+            Text("Build Configuration")
+                .font(.title2)
+                .fontWeight(.bold)
+            
+            // JDK Image Section
+            VStack(alignment: .leading, spacing: 10) {
+                Text("JDK Image")
+                    .font(.headline)
+                
+                JDKSelectorView(
+                    configuration: $configuration,
+                    isCustomImage: $isCustomImage,
+                    customImage: $customImage
+                )
+            }
+            
+            // Build Tool Section
+            VStack(alignment: .leading, spacing: 10) {
+                Text("Build Tool")
+                    .font(.headline)
+                
+                Picker("Build Tool", selection: $configuration.buildTool) {
+                    Text("javac").tag(BuildConfiguration.BuildTool.javac)
+                    Text("Maven").tag(BuildConfiguration.BuildTool.maven)
+                    Text("Gradle").tag(BuildConfiguration.BuildTool.gradle)
+                }
+                .pickerStyle(.segmented)
+            }
+            
+            // Custom Args Section
+            VStack(alignment: .leading, spacing: 10) {
+                Text("Custom Arguments")
+                    .font(.headline)
+                
+                TextField("e.g., -Xmx2g", text: .constant(""))
+                    .textFieldStyle(.roundedBorder)
+            }
+            
+            Spacer()
+            
+            // Save Button
+            Button(action: saveConfiguration) {
+                Text("Save Settings")
+                    .frame(maxWidth: .infinity)
+            }
+            .buttonStyle(.borderedProminent)
+            .controlSize(.large)
+        }
+        .padding()
+        .frame(minWidth: 400, minHeight: 500)
+        .onAppear {
+            loadConfiguration()
+        }
+    }
+    
+    private func loadConfiguration() {
+        if let config = try? service.load() {
+            configuration = config
+        }
+    }
+    
+    private func saveConfiguration() {
+        if isCustomImage && !customImage.isEmpty {
+            let customJDK = JDKConfiguration(
+                id: UUID(),
+                name: "Custom",
+                image: customImage,
+                version: "custom",
+                isCustom: true
+            )
+            configuration.selectedJDK = customJDK
+        }
+        
+        try? service.save(configuration)
+    }
+}
+
+struct JDKSelectorView: View {
+    @Binding var configuration: BuildConfiguration
+    @Binding var isCustomImage: Bool
+    @Binding var customImage: String
+    
+    var body: some View {
+        VStack(alignment: .leading, spacing: 10) {
+            if !isCustomImage {
+                Picker("JDK Image", selection: $configuration.selectedJDK) {
+                    ForEach(JDKConfiguration.predefined) { jdk in
+                        Text(jdk.name).tag(jdk)
+                    }
+                }
+                .pickerStyle(.menu)
+            } else {
+                TextField("Custom Image (e.g., eclipse-temurin:21)", text: $customImage)
+                    .textFieldStyle(.roundedBorder)
+            }
+            
+            Toggle("Use custom image", isOn: $isCustomImage)
+                .font(.subheadline)
+        }
+    }
+}
+
+#Preview {
+    BuildConfigurationView()
+}

--- a/Tests/ZeroTests/BuildConfigurationViewTests.swift
+++ b/Tests/ZeroTests/BuildConfigurationViewTests.swift
@@ -1,0 +1,45 @@
+import XCTest
+import SwiftUI
+import ViewInspector
+@testable import Zero
+
+@MainActor
+class BuildConfigurationViewTests: XCTestCase {
+    
+    func testBuildConfigurationViewRenders() throws {
+        // Given
+        let view = BuildConfigurationView()
+        
+        // Then
+        XCTAssertNoThrow(try view.inspect().find(text: "Build Configuration"))
+    }
+    
+    func testJDKSelectorRenders() throws {
+        // Given
+        let view = BuildConfigurationView()
+        
+        // Then
+        XCTAssertNoThrow(try view.inspect().find(text: "JDK Image"))
+    }
+    
+    func testBuildToolSelectorRenders() throws {
+        // Given
+        let view = BuildConfigurationView()
+        
+        // Then
+        XCTAssertNoThrow(try view.inspect().find(text: "Build Tool"))
+    }
+}
+
+@MainActor
+class JDKSelectorViewTests: XCTestCase {
+    
+    func testJDKSelectorShowsPredefinedOptions() throws {
+        // Given
+        let config = BuildConfiguration.default
+        let view = JDKSelectorView(configuration: .constant(config))
+        
+        // Then
+        XCTAssertNoThrow(try view.inspect().find(Picker.self))
+    }
+}


### PR DESCRIPTION
## Context
- **Issue**: IDE-9
- **Type**:
  - [x] feat
  - [x] test

## Summary
Build Configuration UI 구현 - JDK 이미지 선택 및 빌드 도구 설정 화면.

## Key Changes
- test: BuildConfigurationView UI 테스트 추가
- feat: BuildConfigurationView 구현
- feat: JDKSelectorView 구현 (드롭다운 + 커스텀 이미지 토글)
- refactor: JDKConfiguration에 Hashable 추가 (Picker 지원)

## UI 구성
- JDK Image 선택 (미리 정의된 목록 또는 커스텀)
- Build Tool 선택 (javac/Maven/Gradle)
- Custom Arguments 입력
- 설정 저장 버튼

## 다음 단계
- ExecutionService 연동
- 설정 패널 메뉴에 통합

## 리뷰 포인트
- UI 레이아웃 적절한지 확인
- 커스텀 이미지 토글 UX 확인