### PR TITLE
feature/IDE-11-container-jdk-image | 컨테이너 생성 개선

### DIFF
--- a/Sources/Zero/Services/ContainerOrchestrator.swift
+++ b/Sources/Zero/Services/ContainerOrchestrator.swift
@@ -3,11 +3,13 @@ import Foundation
 class ContainerOrchestrator {
     private let dockerService: DockerServiceProtocol
     private let sessionManager: SessionManager
+    private let buildConfigService: BuildConfigurationService
     private let baseImage = Constants.Docker.baseImage
     
-    init(dockerService: DockerServiceProtocol, sessionManager: SessionManager) {
+    init(dockerService: DockerServiceProtocol, sessionManager: SessionManager, buildConfigService: BuildConfigurationService = FileBasedBuildConfigurationService()) {
         self.dockerService = dockerService
         self.sessionManager = sessionManager
+        self.buildConfigService = buildConfigService
     }
     
     /// 전체 플로우 실행: 컨테이너 생성 -> Clone -> 세션 저장
@@ -15,11 +17,19 @@ class ContainerOrchestrator {
         // 1. 컨테이너 이름 생성 (고유 ID)
         let containerName = "zero-dev-\(UUID().uuidString.prefix(8).lowercased())"
         
-        // 2. 컨테이너 실행
-        _ = try dockerService.runContainer(image: baseImage, name: containerName)
+        // 2. 프로젝트 타입에 따른 이미지 선택
+        let image = try await selectImage(for: repo)
         
-        // 2-1. Git 설치 (Alpine 이미지에 git이 없으므로 설치 필요)
-        _ = try dockerService.executeShell(container: containerName, script: "apk add --no-cache git")
+        // 3. 컨테이너 실행
+        _ = try dockerService.runContainer(image: image, name: containerName)
+        
+        // 3-1. Git 설치 (Alpine 기반 이미지에 git이 없을 경우)
+        if image.contains("alpine") {
+            _ = try? dockerService.executeShell(container: containerName, script: "apk add --no-cache git")
+        } else if image.contains("openjdk") || image.contains("temurin") || image.contains("corretto") {
+            // JDK 이미지들은 보통 Debian/Ubuntu 기반이므로 apt 사용
+            _ = try? dockerService.executeShell(container: containerName, script: "apt-get update && apt-get install -y git")
+        }
         
         // 3. Git Clone (토큰 주입)
         // DockerServiceProtocol이 ContainerRunning을 상속받으므로 직접 전달 가능
@@ -44,5 +54,30 @@ class ContainerOrchestrator {
     func deleteSession(_ session: Session) throws {
         try dockerService.removeContainer(name: session.containerName)
         try sessionManager.deleteSession(session)
+    }
+    
+    /// 프로젝트 타입에 따른 이미지 선택
+    private func selectImage(for repo: Repository) async throws -> String {
+        // 저장소 이름/설명에서 프로젝트 타입 추정
+        let repoLower = repo.name.lowercased()
+        
+        // Java 프로젝트 감지
+        if repoLower.contains("java") || repoLower.contains("spring") || repoLower.contains("maven") || repoLower.contains("gradle") {
+            let config = try buildConfigService.load()
+            return config.selectedJDK.image
+        }
+        
+        // Node.js 프로젝트 감지
+        if repoLower.contains("node") || repoLower.contains("react") || repoLower.contains("vue") || repoLower.contains("angular") {
+            return "node:20-alpine"
+        }
+        
+        // Python 프로젝트 감지
+        if repoLower.contains("python") || repoLower.contains("django") || repoLower.contains("flask") {
+            return "python:3.11-alpine"
+        }
+        
+        // 기본 이미지
+        return baseImage
     }
 }

--- a/docs/specs/IDE-11-container-jdk-image.md
+++ b/docs/specs/IDE-11-container-jdk-image.md
@@ -1,0 +1,28 @@
+# IDE-11: 컨테이너 생성 개선
+
+## 목표
+Alpine Linux 기본 이미지 대신 설정된 JDK 이미지를 사용하여 Java 프로젝트 컨테이너를 생성.
+
+## 구현 내용
+
+### 1. ContainerOrchestrator 개선
+- 설정된 JDK 이미지로 컨테이너 생성
+- Java 프로젝트 감지 시 JDK 이미지 사용
+- 그 외 프로젝트는 기존 Alpine 사용
+
+### 2. SessionManager 연동
+- 세션 생성 시 BuildConfigurationService 조회
+- 프로젝트 타입에 따른 이미지 선택
+
+### 3. 자동 이미지 선택 로직
+- pom.xml/build.gradle → 설정된 JDK 이미지
+- package.json → Node 이미지
+- 그 외 → Alpine
+
+## 변경 파일
+- Sources/Zero/Services/ContainerOrchestrator.swift (수정)
+- Sources/Zero/Services/SessionManager.swift (수정)
+
+## 테스트
+- ContainerOrchestrator 테스트
+- Java 프로젝트 컨테이너 생성 테스트


### PR DESCRIPTION
## Context
- **Issue**: IDE-11
- **Type**:
  - [x] feat

## Summary
프로젝트 타입에 따라 적절한 이미지로 컨테이너 생성. Java 프로젝트는 설정된 JDK 이미지 사용.

## Key Changes
- feat: ContainerOrchestrator에 BuildConfigurationService 연동
- feat: selectImage 메서드 추가 (프로젝트 타입별 이미지 선택)
- feat: Java 프로젝트 감지 시 설정된 JDK 이미지 사용
- feat: Node.js/Python 프로젝트 감지 및 전용 이미지 사용
- feat: Git 설치 로직을 이미지 타입별로 분기

## 이미지 선택 로직
- Java (spring/maven/gradle) → 설정된 JDK 이미지
- Node.js (react/vue/angular) → node:20-alpine
- Python (django/flask) → python:3.11-alpine
- 기타 → alpine:latest

## 다음 단계
- IDE-12: Maven/Gradle 자동 감지 및 실행