### PR TITLE
refactor(editor): remove stdout print on theme load failure

### DIFF
--- a/Sources/Zero/Views/CodeEditorView.swift
+++ b/Sources/Zero/Views/CodeEditorView.swift
@@ -82,12 +82,12 @@ class HighlightedTextView: NSTextView {
         super.mouseDown(with: event)
     }
     
-    func setup(language: String) {
+    func setup(language: String, themeName: String = "xcode") {
         self.currentLanguage = language
         
         highlightr = Highlightr()
-        if highlightr?.setTheme(to: "xcode") == false {
-            print("Failed to load theme: xcode")
+        if highlightr?.setTheme(to: themeName) == false {
+            AppLogStore.shared.append("Failed to load theme: \(themeName)")
         }
         
         isEditable = true

--- a/Tests/ZeroTests/CodeEditorViewTests.swift
+++ b/Tests/ZeroTests/CodeEditorViewTests.swift
@@ -1,0 +1,58 @@
+import XCTest
+import Darwin
+import Foundation
+@testable import Zero
+
+@MainActor
+final class CodeEditorViewTests: XCTestCase {
+    override func setUp() {
+        super.setUp()
+        AppLogStore.shared.clear()
+    }
+
+    override func tearDown() {
+        AppLogStore.shared.clear()
+        super.tearDown()
+    }
+
+    func testSetupWithInvalidThemeDoesNotPrintToStdout() {
+        let textView = HighlightedTextView(frame: .zero)
+
+        let stdout = captureStdout {
+            textView.setup(language: "swift", themeName: "__invalid_theme__")
+        }
+
+        XCTAssertTrue(stdout.trimmingCharacters(in: CharacterSet.whitespacesAndNewlines).isEmpty)
+    }
+
+    func testSetupWithInvalidThemeAppendsFailureToAppLogStore() {
+        let textView = HighlightedTextView(frame: .zero)
+
+        textView.setup(language: "swift", themeName: "__invalid_theme__")
+
+        let logEntries = AppLogStore.shared.recentEntries()
+        XCTAssertTrue(logEntries.contains { entry in
+            entry.contains("Failed to load theme") && entry.contains("__invalid_theme__")
+        })
+    }
+
+    private func captureStdout(_ operation: () -> Void) -> String {
+        fflush(stdout)
+
+        let outputPipe = Pipe()
+        let originalStdout = dup(STDOUT_FILENO)
+        dup2(outputPipe.fileHandleForWriting.fileDescriptor, STDOUT_FILENO)
+
+        operation()
+
+        fflush(stdout)
+        dup2(originalStdout, STDOUT_FILENO)
+        close(originalStdout)
+
+        outputPipe.fileHandleForWriting.closeFile()
+        let outputData = outputPipe.fileHandleForReading.readDataToEndOfFile()
+        outputPipe.fileHandleForReading.closeFile()
+
+        return String(data: outputData, encoding: .utf8) ?? ""
+    }
+}


### PR DESCRIPTION
## Summary
- stop writing theme-load failure messages to stdout in `HighlightedTextView.setup`
- keep observability by appending theme-load failures to `AppLogStore`
- add regression tests to confirm invalid-theme setup emits no stdout while preserving log entries

Closes #100

## Test Plan
- swift test --filter CodeEditorViewTests
- swift test
- swift build -c release