### PR TITLE
refactor(run-profile): log corrupted store decode failures

### DIFF
--- a/Sources/Zero/Services/RunProfileService.swift
+++ b/Sources/Zero/Services/RunProfileService.swift
@@ -56,11 +56,15 @@ class FileBasedRunProfileService: RunProfileService {
             return [:]
         }
 
-        guard let store = try? JSONDecoder().decode(RunProfileStore.self, from: data) else {
+        do {
+            let store = try JSONDecoder().decode(RunProfileStore.self, from: data)
+            return store.commandsByRepository
+        } catch {
+            AppLogStore.shared.append(
+                "RunProfileService decode failed for \(configPath): \(error.localizedDescription)"
+            )
             return [:]
         }
-
-        return store.commandsByRepository
     }
 
     private func writeCommands(_ commands: [String: String]) throws {


### PR DESCRIPTION
## Summary
- preserve existing corrupted-store fallback behavior by returning an empty command map
- append decode failure details to `AppLogStore` when `run-profiles.json` cannot be decoded
- add regression coverage for corrupted-store load path observability

Closes #104

## Test Plan
- swift test --filter RunProfileServiceTests
- swift test
- swift build -c release